### PR TITLE
Add error handling middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 [![Build Status](https://travis-ci.org/bufferapp/buffer-rpc.svg?branch=master)](https://travis-ci.org/bufferapp/buffer-rpc)
 
 Buffer RPC request handler
+
+## Error Handling
+
+### Handled Flag
+
+**createError** handled = true (customizable)
+
+**errorMiddleware** handled = false
+
+**method not found** handled = true
+
+### Error Codes
+
+**defaults**
+
+1000 - createError default (customizable)
+4040 - method not found (404)
+5000 - unhandled exception (500)

--- a/src/createError.js
+++ b/src/createError.js
@@ -1,7 +1,13 @@
-module.exports = ({ message, code = 1000, statusCode = 400 }) => {
+module.exports = ({
+  message,
+  code = 1000,
+  statusCode = 400,
+  handled = true,
+}) => {
   const error = new Error(message)
-  error.handled = true
+  error.rpcError = true
   error.code = code
   error.statusCode = statusCode
+  error.handled = handled
   return error
 }

--- a/src/errorMiddleware.js
+++ b/src/errorMiddleware.js
@@ -4,5 +4,7 @@ module.exports = (error, req, res, next) => {
   }
   res.status(500).send({
     error: error.message,
+    code: 1000,
+    handled: false,
   })
 }

--- a/src/errorMiddleware.js
+++ b/src/errorMiddleware.js
@@ -4,7 +4,7 @@ module.exports = (error, req, res, next) => {
   }
   res.status(500).send({
     error: error.message,
-    code: 1000,
+    code: 5000,
     handled: false,
   })
 }

--- a/src/errorMiddleware.js
+++ b/src/errorMiddleware.js
@@ -1,22 +1,8 @@
-module.exports = (hooks = {}) => async (error, req, res, next) => {
-  if (hooks.beforeSend) {
-    try {
-      await hooks.beforeSend(req, res)
-    } catch (beforeSendError) {
-      return next(beforeSendError)
-    }
-  }
+module.exports = (error, req, res, next) => {
   if (res.headersSent) {
     return next(error)
   }
   res.status(500).send({
     error: error.message,
   })
-  if (hooks.afterSend) {
-    try {
-      await hooks.afterSend(req, res)
-    } catch (afterSendError) {
-      return next(afterSendError)
-    }
-  }
 }

--- a/src/errorMiddleware.js
+++ b/src/errorMiddleware.js
@@ -1,0 +1,22 @@
+module.exports = (hooks = {}) => async (error, req, res, next) => {
+  if (hooks.beforeSend) {
+    try {
+      await hooks.beforeSend(req, res)
+    } catch (beforeSendError) {
+      return next(beforeSendError)
+    }
+  }
+  if (res.headersSent) {
+    return next(error)
+  }
+  res.status(500).send({
+    error: error.message,
+  })
+  if (hooks.afterSend) {
+    try {
+      await hooks.afterSend(req, res)
+    } catch (afterSendError) {
+      return next(afterSendError)
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 const rpc = require('./rpc')
 const method = require('./method')
 const createError = require('./createError')
+const errorMiddleware = require('./errorMiddleware')
 
 module.exports = {
   rpc,
   method,
   createError,
+  errorMiddleware,
 }

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -38,10 +38,11 @@ module.exports = (...methods) => (req, res, next) => {
     }
     // handle request the same for sync or async
     promise.then(result => res.send({ result })).catch(error => {
-      if (error.handled) {
+      if (error.rpcError) {
         res.status(error.statusCode || 400).send({
           error: error.message,
           code: error.code,
+          handled: error.handled,
         })
       } else {
         next(error)
@@ -50,6 +51,8 @@ module.exports = (...methods) => (req, res, next) => {
   } else {
     res.status(404).send({
       error: 'unknown method',
+      code: 4040,
+      handled: true,
     })
   }
 }

--- a/test/createError.test.js
+++ b/test/createError.test.js
@@ -8,6 +8,8 @@ describe('createError', () => {
     })
     expect(error.message).toBe(message)
     expect(error.statusCode).toBe(400)
+    expect(error.handled).toBe(true)
+    expect(error.rpcError).toBe(true)
   })
 
   it('should create an error with a custom status code', () => {
@@ -19,6 +21,8 @@ describe('createError', () => {
     })
     expect(error.message).toBe(message)
     expect(error.statusCode).toBe(statusCode)
+    expect(error.handled).toBe(true)
+    expect(error.rpcError).toBe(true)
   })
 
   it('should create an error with default code', () => {
@@ -29,6 +33,8 @@ describe('createError', () => {
     })
     expect(error.message).toBe(message)
     expect(error.code).toBe(code)
+    expect(error.handled).toBe(true)
+    expect(error.rpcError).toBe(true)
   })
 
   it('should create an error with custom code', () => {
@@ -40,5 +46,20 @@ describe('createError', () => {
     })
     expect(error.message).toBe(message)
     expect(error.code).toBe(code)
+    expect(error.handled).toBe(true)
+    expect(error.rpcError).toBe(true)
+  })
+
+  it('should create an error that is handled = false', () => {
+    const message = 'some error'
+    const handled = false
+    const error = createError({
+      message,
+      handled,
+    })
+    expect(error.message).toBe(message)
+    expect(error.statusCode).toBe(400)
+    expect(error.handled).toBe(handled)
+    expect(error.rpcError).toBe(true)
   })
 })

--- a/test/errorMiddleware.test.js
+++ b/test/errorMiddleware.test.js
@@ -1,0 +1,85 @@
+const listen = require('test-listen')
+const { createServer, stopServer, generateRequest } = require('./utils')
+const { rpc, method } = require('../src/')
+const errorMiddleware = require('../src/errorMiddleware')
+
+describe('errorMiddleware', () => {
+  it('should return a json error response', async () => {
+    const name = 'someMethod'
+    const errorMessage = 'boom'
+    const server = createServer(
+      rpc(
+        method(name, () => {
+          throw new Error(errorMessage)
+        }),
+      ),
+      errorMiddleware(),
+    )
+    try {
+      let url = await listen(server)
+      await generateRequest({
+        url,
+        name,
+      })
+    } catch (error) {
+      expect(error.statusCode).toBe(500)
+      expect(error.error).toEqual({
+        error: errorMessage,
+      })
+    }
+    stopServer(server)
+  })
+
+  it('should call before send hook before sending error response', async () => {
+    const name = 'someMethod'
+    const errorMessage = 'boom'
+    const message = 'hi'
+    const beforeSend = (req, res) => res.status(200).send({ message })
+    const server = createServer(
+      rpc(
+        method(name, () => {
+          throw new Error(errorMessage)
+        }),
+      ),
+      errorMiddleware({ beforeSend }),
+    )
+    let url = await listen(server)
+    const response = await generateRequest({
+      url,
+      name,
+    })
+    expect(response).toEqual({
+      message,
+    })
+    stopServer(server)
+  })
+
+  it('should call after send hook', async () => {
+    expect.assertions(3)
+    const name = 'someMethod'
+    const errorMessage = 'boom'
+    const afterSend = jest.fn()
+    const server = createServer(
+      rpc(
+        method(name, () => {
+          throw new Error(errorMessage)
+        }),
+      ),
+      errorMiddleware({ afterSend }),
+    )
+    try {
+      let url = await listen(server)
+      await generateRequest({
+        url,
+        name,
+      })
+    } catch (error) {
+      expect(error.statusCode).toBe(500)
+      expect(error.error).toEqual({
+        error: errorMessage,
+      })
+      expect(afterSend).toBeCalled()
+    }
+    stopServer(server)
+  })
+})

--- a/test/errorMiddleware.test.js
+++ b/test/errorMiddleware.test.js
@@ -26,7 +26,7 @@ describe('errorMiddleware', () => {
       expect(error.error).toEqual({
         error: errorMessage,
         handled: false,
-        code: 1000,
+        code: 5000,
       })
     }
     stopServer(server)

--- a/test/errorMiddleware.test.js
+++ b/test/errorMiddleware.test.js
@@ -25,6 +25,8 @@ describe('errorMiddleware', () => {
       expect(error.statusCode).toBe(500)
       expect(error.error).toEqual({
         error: errorMessage,
+        handled: false,
+        code: 1000,
       })
     }
     stopServer(server)

--- a/test/rpc.test.js
+++ b/test/rpc.test.js
@@ -3,6 +3,7 @@ const listen = require('test-listen')
 const express = require('express')
 const request = require('request-promise')
 const { createServer, stopServer, generateRequest } = require('./utils')
+const createError = require('../src/createError')
 const rpc = require('../src/rpc')
 
 describe('rpc', () => {
@@ -19,6 +20,8 @@ describe('rpc', () => {
       expect(error.statusCode).toBe(404)
       expect(error.error).toEqual({
         error: 'unknown method',
+        handled: true,
+        code: 4040,
       })
     }
     stopServer(server)
@@ -174,9 +177,9 @@ describe('rpc', () => {
     const name = 'name'
     const errorMessage = 'nope'
     const fn = () => {
-      const error = new Error(errorMessage)
-      error.handled = true
-      throw error
+      throw createError({
+        message: errorMessage,
+      })
     }
     const method = {
       name,
@@ -193,6 +196,8 @@ describe('rpc', () => {
       expect(error.statusCode).toBe(400)
       expect(error.error).toEqual({
         error: errorMessage,
+        code: 1000,
+        handled: true,
       })
     }
     stopServer(server)
@@ -203,9 +208,9 @@ describe('rpc', () => {
     const name = 'name'
     const errorMessage = 'nope'
     const fn = async () => {
-      const error = new Error(errorMessage)
-      error.handled = true
-      throw error
+      throw createError({
+        message: errorMessage,
+      })
     }
     const method = {
       name,
@@ -222,6 +227,8 @@ describe('rpc', () => {
       expect(error.statusCode).toBe(400)
       expect(error.error).toEqual({
         error: errorMessage,
+        code: 1000,
+        handled: true,
       })
     }
     stopServer(server)
@@ -233,10 +240,10 @@ describe('rpc', () => {
     const errorMessage = 'nope'
     const statusCode = 401
     const fn = async () => {
-      const error = new Error(errorMessage)
-      error.handled = true
-      error.statusCode = statusCode
-      throw error
+      throw createError({
+        message: errorMessage,
+        statusCode,
+      })
     }
     const method = {
       name,
@@ -253,6 +260,8 @@ describe('rpc', () => {
       expect(error.statusCode).toBe(statusCode)
       expect(error.error).toEqual({
         error: errorMessage,
+        code: 1000,
+        handled: true,
       })
     }
     stopServer(server)
@@ -353,6 +362,7 @@ describe('rpc', () => {
     const fn = async () => {
       const error = new Error(errorMessage)
       error.handled = true
+      error.rpcError = true
       error.code = errorCode
       throw error
     }
@@ -371,6 +381,7 @@ describe('rpc', () => {
       expect(error.error).toEqual({
         error: errorMessage,
         code: errorCode,
+        handled: true,
       })
     }
     stopServer(server)


### PR DESCRIPTION
This middleware returns a 500 with the error in JSON format. It can trigger a next error middleware if before or after hook fail OR if somehow the response was already sent. I'll add more documentation to the README.