### PR TITLE
Allow passing of optional `utils` for RPC Method dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+### Added
+- When composing your RPC handler you can optionally pass an dependencies to be exposed to all RPC methods. See the README section on "Dependency Injection" for more details. This support is optional and existing usage will continue to function.
+
 ## [1.0.0]
 ### Added
 - `buffer-rpc` can now receive calls in the form of `endpoint/:methodName` to allow for clearer debugging and tracing (e.g., in Chrome DevTools and DataDog). The previous method of passing the name to the RPC endpoint as one of the JSON body parameters **is still supported** but the method name in the URI takes precedence. 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,43 @@ const port = 3000
 app.listen(port, () => console.log(`App Is Listening On Port ${port}`))
 ```
 
+## Dependency Injection
+
+To simplify the code in your RPC methods, you may want to pass some common utilities down via simple dependancy injection. To do this, you call the `rpc()` method with slightly different syntax.
+
+Instead of this (seen in the other README examples):
+
+```js
+rpc(methodOne, methodTwo, methodThree, ...);
+```
+
+Pass the methods as an `Array` and pass `utils` as a second parameter:
+
+```js
+rpc([methodOne, methodTwo, methodThree], utils);
+```
+
+Where `utils` is an `Object` that will be exposed to your RPC methods as the last parameter. For example, you might use it like this (example is simplified):
+
+```js
+// rpcHandler.js
+const { rpc } = require('@bufferapp/buffer-rpc');
+
+const PublishAPI = require('./publishAPI');
+const myMethod = require('./myMethod');
+
+module.exports = rpc([myMethod], { PublishAPI });
+
+// myMethod.js
+const { method } = require('@bufferapp/buffer-rpc');
+
+module.exports = method(
+  'myMethod',
+  'myMethodDocs',
+  (args, req, res, { PublishAPI }) => PublishAPI.fetch('/1/user.json')
+);
+```
+
 ## Error Handling
 
 ### Handled Flag

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -1,60 +1,89 @@
-module.exports = (...methods, utils = {}) => (req, res, next) => {
-  if (!req.body) {
-    return next(
-      new Error('no req.body found, is app.use(bodyParser.json()) hooked up?'),
-    )
+/**
+ * Compose our RPC Express route handler. (Typically `/rpc/:method?`).
+
+ * If `methods` passed to this function is NOT an Array then we expect this was 
+ * invoked with methods as each parameter, and so merge everything. E.g., this 
+ * functions was called like so.
+ * 
+ *   rpc(methodOne, methodTwo, methodThree, ...);
+ * 
+ * Otherwise the first param should be an Array of methods and the second an
+ * Object to pass as utilities / dependencies for the RPC methods. E.g.,
+ *  
+ *   rpc([methodOne, methodTwo, ...], { MyUtility, OtherUtil })
+ * 
+ * In the latter case, when RPC methods are called they will have access to the
+ * utility Object via their last parameter. (See where `utils` is passed below.)
+ * 
+ * @returns Function  Handler for RPC requests
+ */
+module.exports = (methods, utils, ...rest) => {
+  let allMethods = methods
+  if (!Array.isArray(methods)) {
+    allMethods = [methods, utils, ...rest].filter(i => i) // filter removes null / undefined
+    utils = null
   }
-  const { name: bodyName, args } = req.body
-  // Try to get the method name from the URL first (e.g., /rpc/:method)
-  // Fall back to checking header or POST body
-  const name = req.params.method || req.headers['x-buffer-rpc-name'] || bodyName
-  const matchingMethod = methods.find(method => method.name === name)
-  if (name === 'methods') {
-    res.send([
-      {
-        name: 'methods',
-        docs: 'list all available methods',
-      },
-      ...methods.map(({ name, docs }) => ({
-        name,
-        docs,
-      })),
-    ])
-  } else if (matchingMethod) {
-    const parsedArgs = args ? JSON.parse(args) : []
-    let promise
-    try {
-      const fnResult = Array.isArray(parsedArgs)
-        ? matchingMethod.fn(...parsedArgs, req, res, utils)
-        : matchingMethod.fn(parsedArgs, req, res, utils)
-      // if async function set it to the promise
-      if (fnResult.then) {
-        promise = fnResult
-      } else {
-        // if sync function wrap in a resolved promise
-        promise = Promise.resolve(fnResult)
-      }
-    } catch (error) {
-      // sync failure, wrap in a rejected promise
-      promise = Promise.reject(error)
+  return (req, res, next) => {
+    if (!req.body) {
+      return next(
+        new Error(
+          'no req.body found, is app.use(bodyParser.json()) hooked up?',
+        ),
+      )
     }
-    // handle request the same for sync or async
-    promise.then(result => res.send({ result })).catch(error => {
-      if (error.rpcError) {
-        res.status(error.statusCode || 400).send({
-          error: error.message,
-          code: error.code,
-          handled: error.handled,
-        })
-      } else {
-        next(error)
+    const { name: bodyName, args } = req.body
+    // Try to get the method name from the URL first (e.g., /rpc/:method)
+    // Fall back to checking header or POST body
+    const name =
+      req.params.method || req.headers['x-buffer-rpc-name'] || bodyName
+    const matchingMethod = allMethods.find(method => method.name === name)
+    if (name === 'methods') {
+      res.send([
+        {
+          name: 'methods',
+          docs: 'list all available methods',
+        },
+        ...allMethods.map(({ name, docs }) => ({
+          name,
+          docs,
+        })),
+      ])
+    } else if (matchingMethod) {
+      const parsedArgs = args ? JSON.parse(args) : []
+      let promise
+      try {
+        const fnResult = Array.isArray(parsedArgs)
+          ? matchingMethod.fn(...parsedArgs, req, res, utils)
+          : matchingMethod.fn(parsedArgs, req, res, utils)
+        // if async function set it to the promise
+        if (fnResult.then) {
+          promise = fnResult
+        } else {
+          // if sync function wrap in a resolved promise
+          promise = Promise.resolve(fnResult)
+        }
+      } catch (error) {
+        // sync failure, wrap in a rejected promise
+        promise = Promise.reject(error)
       }
-    })
-  } else {
-    res.status(404).send({
-      error: 'unknown method',
-      code: 4040,
-      handled: true,
-    })
+      // handle request the same for sync or async
+      promise.then(result => res.send({ result })).catch(error => {
+        if (error.rpcError) {
+          res.status(error.statusCode || 400).send({
+            error: error.message,
+            code: error.code,
+            handled: error.handled,
+          })
+        } else {
+          next(error)
+        }
+      })
+    } else {
+      res.status(404).send({
+        error: 'unknown method',
+        code: 4040,
+        handled: true,
+      })
+    }
   }
 }

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -1,4 +1,4 @@
-module.exports = (...methods) => (req, res, next) => {
+module.exports = (...methods, utils = {}) => (req, res, next) => {
   if (!req.body) {
     return next(
       new Error('no req.body found, is app.use(bodyParser.json()) hooked up?'),
@@ -25,8 +25,8 @@ module.exports = (...methods) => (req, res, next) => {
     let promise
     try {
       const fnResult = Array.isArray(parsedArgs)
-        ? matchingMethod.fn(...parsedArgs, req, res)
-        : matchingMethod.fn(parsedArgs, req, res)
+        ? matchingMethod.fn(...parsedArgs, req, res, utils)
+        : matchingMethod.fn(parsedArgs, req, res, utils)
       // if async function set it to the promise
       if (fnResult.then) {
         promise = fnResult

--- a/test/rpc.test.js
+++ b/test/rpc.test.js
@@ -409,4 +409,37 @@ describe('rpc', () => {
     }
     stopServer(server)
   })
+
+  it('should handle dependency injection for rpc methods', async () => {
+    const name = 'name'
+    const fn = jest.fn((req, res, { Utility }) => {
+      return Promise.resolve(Utility.someFunc())
+    })
+    const method = {
+      name,
+      fn,
+    }
+    // method that doesn't use utils
+    const fnTwo = jest.fn(() => {
+      return Promise.resolve(true)
+    })
+    const methodTwo = {
+      name: 'methodTwo',
+      fn: fnTwo,
+    }
+    const server = createServer(
+      rpc([method, methodTwo], { Utility: { someFunc: jest.fn() } }),
+    )
+    let url = await listen(server)
+    await generateRequest({
+      url,
+      name,
+    })
+    await generateRequest({
+      url,
+      name: 'methodTwo',
+    })
+    expect(fn).toHaveBeenCalled()
+    stopServer(server)
+  })
 })


### PR DESCRIPTION
### Purpose
Allow passing of optional `utils` object to RPC methods. This can simplify RPC method code as we can use dependency injection to provide necessary utilities for data fetching and error handling instead of repeating `require('../../../foo')` in many of our method files.

Built so it's backwards compatible and existing usage will remain functional.

### Impact
<!-- _What products/areas are potentially impacted by these changes?_ -->
- [ ] Publish
- [ ] Analyze
- [ ] Reply
- [ ] Mobile
- [ ] Data Tracking
- [ ] Global Admin
- [ ] Buffer Admin
- [ ] Reply HQ
- [ ] Security (anything involving access tokens, exposing APIs, etc.)
- [x] Other (please explain)

### Related Links 
<!-- _JIRA tickets, other PRs, Paper docs, etc._ -->

### Priority
<!-- _If you're someone outside of the Core team, please describe the priority of this work for your product team.  For example is it blocking some other high priority work, is it a critical bug fix, is it needed for a scheduled release in a week, etc._ -->

### Notes

### Review

#### Staging Deployment

<!--
### Instructions for Folks Outside of Core Creating PRs
- Please add at least one Core engineer as a reviewer
- Be sure to fill in the Purpose, Impact, and Priority sections above
- Ping the Core team in Slack (you can use @-core in #collab-analyze-core, #collab-reply-core, or #prod-core depending on what team you're in) to give a heads up that the PR is ready for review.  If the change is urgent/critical, include this context.
- Wait for a Core engineer to get back to you.  If the scope of the changes feels small and the risk feels low, the Core team may give you the green light to go ahead and merge the changes now and we'll circle back with the review afterwards.  If the changes feel more risky or have a broader impact, we may ask that you wait to merge the changes until someone from Core has had a chance to review the changes.
- After your changes have been merged and deployed, please monitor Bugsnag to see if any new errors are reported.
-->
<!--
### Instructions for Core Engineers Added As Reviewers For PRs Created by Folks Outside of Core
- When a request for a code review comes in, do a quick assessment of whether this is a PR that Core needs to review before merging, and let the engineer know.
- If the change does require a Core engineer to do a code review before merging, work with the engineer (and the EMs/PMs if necessary) to determine the priority of this code review relative to Core's current priorities.  Clearly set expectations with the requestor about when the review will be completed.
- Review all code changes through the same lens as if the Core team were making these changes.  Remember that not all teams operate with the same processes depending on the lifecycle phase that their product is in, and that Core services shared between products need to be held to a quality bar that serves each of those products. 
-->
